### PR TITLE
Add documentation for .gitkeep file usage in Git

### DIFF
--- a/contents/docs/file-management-in-git/the-gitkeep-file/index.mdx
+++ b/contents/docs/file-management-in-git/the-gitkeep-file/index.mdx
@@ -1,0 +1,84 @@
+### Understanding the .gitkeep File in Git
+
+---
+
+#### Introduction
+The `.gitkeep` file is a convention used in Git to ensure that empty directories are tracked within a repository. Unlike `.gitignore`, `.gitkeep` doesn't tell Git to ignore files; instead, it serves as a placeholder file to force Git to recognize and include an otherwise empty directory.
+
+---
+
+### Getting Started
+
+#### What is a .gitkeep File?
+The `.gitkeep` file is an empty file added to a directory so that Git tracks the directory, even when the directory is otherwise empty. Since Git does not track empty directories, `.gitkeep` solves this problem.
+
+#### Why Use a .gitkeep File?
+- Preserves directory structure in the repository, even if the directory currently has no other files.
+- Useful when a directory is intended to hold files generated later, ensuring the directory structure is in place from the start.
+- Allows project structure to be maintained and communicated through version control.
+
+#### How to Create a .gitkeep File
+1. **Manually**: Create a file named `.gitkeep` inside the directory you want to track using any text editor or command line.
+   Example (Linux/Windows command line):
+   ```bash
+   touch path/to/your/directory/.gitkeep
+   ```
+
+---
+
+### Basic Concepts
+
+#### Syntax and Rules
+The `.gitkeep` file is typically empty. Its existence alone is enough to instruct Git to track the directory.
+1. **Add to Any Directory**:
+   ```plaintext
+   path/to/your/directory/.gitkeep
+   ```
+2. **Content Doesn't Matter**:
+   While traditionally empty, the content of `.gitkeep` files is ignored by Git.
+
+#### Common Examples
+```plaintext
+# Example directory structure
+
+data/.gitkeep
+logs/.gitkeep
+temp/.gitkeep
+```
+
+---
+
+### Essential Commands
+
+#### Add and Use .gitkeep
+1. Create the `.gitkeep` file in the desired directory.
+2. Add the `.gitkeep` file to Git tracking:
+   ```bash
+   git add path/to/your/directory/.gitkeep
+   ```
+3. Commit the changes:
+   ```bash
+   git commit -m "Add .gitkeep file(s) to track empty directories"
+   ```
+
+#### Verify Directory Tracking
+To verify that the directory is being tracked, check the Git status:
+```bash
+git status
+```
+The directory with `.gitkeep` should appear in the list of changes to be committed.
+
+---
+
+### Best Practices
+
+1. **Consistency**: Use `.gitkeep` consistently across your project to ensure uniform directory tracking.
+2. **Documentation**: Document the purpose of directories with `.gitkeep` files, especially if their intended use isn't immediately obvious.
+3. **Don't Add Actual Content**: The `.gitkeep` file should remain empty to avoid confusion about its purpose.
+4. **Consider Alternatives**: Evaluate if other files might naturally exist in the directory over time, which would remove the need for `.gitkeep`.
+
+---
+
+### Conclusion
+
+The `.gitkeep` file is a simple but effective convention for tracking empty directories in Git. By using it, you can maintain your project's directory structure and ensure that important directories are preserved, even when they don't yet contain other files. Always use `.gitkeep` intentionally to communicate the planned structure of your project. 🚀

--- a/lib/routes-config.ts
+++ b/lib/routes-config.ts
@@ -78,7 +78,9 @@ export const ROUTES: EachRoute[] = [
     title: "File Management in Git",
     href: "/file-management-in-git",
     noLink: true,
-    items: [{ title: "The .gitignore File", href: "/the-gitignore-file" }],
+    items: [{ title: "The .gitignore File", href: "/the-gitignore-file" },
+            { title: "The .gitkeep File", href: "/the-gitkeep-file" },
+           ],
   },
 
 ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive guide titled "Understanding the .gitkeep File in Git," which explains the role and best practices of using `.gitkeep` to preserve empty directories in Git repositories. The guide covers practical examples, commands, and usage tips to enhance project organization.
  - Expanded navigation options in the "File Management in Git" section by adding a link to the new `.gitkeep` document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->